### PR TITLE
Add core dataset upload code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,7 @@ wheel:
 	rm -rf dist build src/*.egg-info
 	uvx pip wheel -w dist .
 .PHONY: test-release
-test-release: wheel
-	uvx twine check dist/*airtrain*.whl
-	uvx twine upload --repository testpypi dist/*airtrain*.whl
 
-.PHONY: release
-release: wheel
-	uvx twine check dist/*airtrain*.whl
-	uvx twine upload dist/*airtrain*.whl
-
-.PHONY: test-release
 test-release: wheel
 	uvx twine check dist/*airtrain*.whl
 	uvx twine upload --repository testpypi dist/*airtrain*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,7 @@ enabled = true
 [[tool.mypy.overrides]]
 module = "airtrain.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pyarrow.*"
+ignore_missing_imports = true

--- a/src/airtrain/__init__.py
+++ b/src/airtrain/__init__.py
@@ -1,2 +1,6 @@
 from airtrain.client import set_api_key  # noqa: F401
-from airtrain.core import DatasetMetadata, upload_from_dicts  # noqa: F401
+from airtrain.core import (  # noqa: F401
+    DatasetMetadata,
+    upload_from_arrow_tables,
+    upload_from_dicts,
+)

--- a/src/airtrain/client.py
+++ b/src/airtrain/client.py
@@ -84,6 +84,14 @@ class AirtrainClient:
                 "function airtrain.set_api_key"
             )
 
+    def dataset_dashboard_url(self, dataset_id: str) -> str:
+        """Get the webapp URL for a dataset, given its id."""
+        api_url = self._base_url
+        app_url = api_url.replace("://api.dev", "://airtrain.dev").replace(
+            "://api.", "://app."
+        )
+        return f"{app_url}/dataset/{dataset_id}"
+
     def trigger_dataset_ingest(self, dataset_id: str) -> TriggerIngestResponse:
         """Wraps: POST /dataset/[id]/ingest"""
         response = self._post_json(url_path=f"dataset/{dataset_id}/ingest", content={})

--- a/src/airtrain/core.py
+++ b/src/airtrain/core.py
@@ -1,5 +1,39 @@
+import io
+import logging
+import sys
+from collections import defaultdict
 from dataclasses import dataclass, fields
-from typing import Any, Dict, Iterable, Union
+from datetime import datetime
+from itertools import islice
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypeVar
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pyarrow.compute import count as count_arrow
+
+from airtrain.client import client
+
+
+if sys.version_info > (3, 11):
+    from typing import TypedDict, Unpack
+
+    class CreationArgs(TypedDict):
+        name: Optional[str]
+        embedding_column: Optional[str]
+else:
+    # Unpack is only >3.11 . We'll just rely on type
+    # checking in those versions to catch mistakes.
+    # This will make Unpack[CreationArgs] into
+    # Optional[Any] for lower versions, which should
+    # pass checks.
+    from typing import Optional as Unpack  # noqa
+    from typing import Any as CreationArgs  # noqa
+
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_BATCH_SIZE: int = 2000
 
 
 @dataclass
@@ -20,12 +54,199 @@ class DatasetMetadata:
 
 def upload_from_dicts(
     data: Iterable[Dict[str, Any]],
-    name: Union[str, None] = None,
-    embedding_column: Union[str, None] = None,
+    schema: Optional[pa.Schema] = None,
+    **kwargs: Unpack[CreationArgs],
 ) -> DatasetMetadata:
-    return DatasetMetadata(
-        name=name or "My Dataset",
-        id="abc123",
-        url="https://example.com",
-        size=0,
+    """Upload an Airtrain dataset from the provided dictionaries.
+
+    Parameters
+    ----------
+    data:
+        An iterable of dictionary data to construct an Airtrain dataset out of.
+        Each row in the data must be a python dictionary, and use only types
+        that can be converted into pyarrow types. Data will be intermediately
+        represented as pyarrow tables.
+    schema:
+        Optionally, the Arrow schema the data conforms to. If not provided, the
+        schema will be inferred from a sample of the data.
+    kwargs:
+        See `upload_from_arrow_tables` for other arguments.
+
+    Returns
+    -------
+    A DatasetMetadata object summarizing the created dataset.
+    """
+    data = iter(data)  # to ensure itertools works even if it was a list, etc.
+    batches = _batched(data, _MAX_BATCH_SIZE)
+    return upload_from_arrow_tables(
+        data=_dict_batches_to_tables(batches, schema),
+        **kwargs,
     )
+
+
+def _is_arrow_number(type_: pa.DataType) -> bool:
+    checks = [
+        pa.types.is_floating,
+        pa.types.is_integer,
+        pa.types.is_decimal,
+    ]
+    return any(check(type_) for check in checks)
+
+
+def _validate_embedding_field(
+    table: pa.Table, embedding_column: str, expected_dim: Optional[int] = None
+) -> int:
+    if embedding_column not in table.column_names:
+        raise ValueError(f"No column named '{embedding_column}' containing embeddings.")
+    column_type = table.schema.field(embedding_column).type
+    if (
+        pa.types.is_list(column_type)
+        or pa.types.is_large_list(column_type)
+        or pa.types.is_fixed_size_list(column_type)
+    ):
+        val_type = column_type.value_type
+        if not _is_arrow_number(val_type):
+            raise TypeError(
+                f"Embedding column must contain lists of numbers, not list of {val_type}"
+            )
+        first_vec_dimensions = len(table[embedding_column][0])
+        if expected_dim is None:
+            expected_dim = first_vec_dimensions
+        if expected_dim != first_vec_dimensions:
+            raise ValueError(
+                f"Expected embeddings to have {expected_dim} "
+                f"dimensions, got: {first_vec_dimensions}"
+            )
+        as_fixed_dim = pa.list_(val_type, expected_dim)
+        column = table[embedding_column]
+        try:
+            column.cast(as_fixed_dim)
+        except pa.lib.ArrowInvalid:
+            raise ValueError(
+                f"Not all embeddings in '{embedding_column}' were "
+                f"{expected_dim} dimensions."
+            )
+
+        n_nulls = count_arrow(column, mode="only_null").as_py()
+        if n_nulls > 0:
+            raise ValueError(f"Found {n_nulls} null values in '{embedding_column}'")
+
+    else:
+        raise TypeError(
+            f"Embedding column must contain lists of numbers. Got: {column_type}"
+        )
+    return expected_dim
+
+
+def upload_from_arrow_tables(
+    data: Iterable[pa.Table],
+    name: Optional[str] = None,
+    embedding_column: Optional[str] = None,
+) -> DatasetMetadata:
+    """Upload an Airtrain dataset from the provided dictionaries.
+
+    Parameters
+    ----------
+    data:
+        An iterable of arrow tables to construct an Airtrain dataset out of.
+        Each row in the data must be an arrow table, and all tables must have
+        the same schema.
+    name:
+        The name of the dataset you are creating, which will be shown in the
+        Airtrain dashboard.
+    embedding_column:
+        The name of a column containing pre-computed embeddings for the data.
+        The column must have non-null values for every row. Every row must be
+        a list of numewric values, representing the embedding vector. All
+        vectors must have the same dimensionality (length).
+
+    Returns
+    -------
+    A DatasetMetadata object summarizing the created dataset.
+    """
+    name = name or f"My Dataset {datetime.now()}"
+    c = client()
+    creation_call_result = c.create_dataset(
+        name=name, embedding_column_name=embedding_column
+    )
+    limit = creation_call_result.row_limit
+    dataset_id = creation_call_result.dataset_id
+    size = 0
+    embedding_dim: Optional[int] = None
+    schema: Optional[pa.Schema] = None
+
+    for table in data:
+        if schema is None:
+            schema = table.schema
+        if schema != table.schema:
+            logger.error("Mismatched schemas:\n%s\n\n%s", schema, table.schema)
+            raise ValueError("All uploaded tables must have the same schema.")
+        if embedding_column is not None:
+            embedding_dim = _validate_embedding_field(
+                table, embedding_column, embedding_dim
+            )
+        table = table[: limit - size]
+
+        upload_buffer = io.BytesIO()
+        pq.write_table(table, upload_buffer)
+        upload_buffer.seek(0)
+        c.upload_dataset_data(dataset_id, upload_buffer)
+        size += table.shape[0]
+
+        if size >= limit:
+            break
+
+    if size == 0:
+        raise ValueError("Cannot ingest empty dataset.")
+    c.trigger_dataset_ingest(dataset_id)
+    return DatasetMetadata(
+        name=name,
+        id=dataset_id,
+        url=c.dataset_dashboard_url(dataset_id),
+        size=size,
+    )
+
+
+T = TypeVar("T")
+
+
+def _dict_batches_to_tables(
+    batches: Iterable[Tuple[Dict[str, Any], ...]], schema: Optional[pa.Schema] = None
+) -> Iterable[pa.Table]:
+    for batch in batches:
+        table = _dicts_to_table(batch, schema)
+        if schema is None:
+            # ensure later batches use the same schema.
+            schema = table.schema
+        yield table
+
+
+def _dicts_to_table(
+    dicts: Tuple[Dict[str, Any], ...], schema: Optional[pa.Schema]
+) -> pa.Table:
+    columns: Set[str] = set()
+    for row in dicts:
+        if not isinstance(row, dict):
+            logger.error("Unexpected row: %s", row)
+            raise ValueError("All data rows must be python dicts.")
+        columns.update(row.keys())
+
+    table_dict: Dict[str, List[Any]] = defaultdict(list)
+    for row in dicts:
+        for column in columns:
+            table_dict[column].append(row.get(column))
+    return pa.table(table_dict, schema=schema)
+
+
+# This is in the standard lib in itertools as of 3.12; this code
+# is adapted from documentation there.
+def _batched(iterable: Iterable[T], n: int) -> Iterable[Tuple[T, ...]]:
+    if n < 1:
+        raise ValueError("n must be at least one")
+    iterator = iter(iterable)
+    batch: Tuple[T, ...] = ()
+    while True:
+        batch = tuple(islice(iterator, n))
+        if len(batch) == 0:
+            break
+        yield batch

--- a/src/tests/fixtures.py
+++ b/src/tests/fixtures.py
@@ -1,0 +1,75 @@
+import io
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from unittest.mock import patch, MagicMock
+
+import pyarrow as pa
+import pytest
+from pyarrow import parquet as pq
+
+from airtrain.client import (
+    AirtrainClient,
+    CreateDatasetResponse,
+    NotFoundError,
+    TriggerIngestResponse,
+    client,
+)
+
+
+@pytest.fixture
+def mock_client():
+    client.cache_clear()
+    mock = MagicMock()
+    mock.return_value = MockAirtrainClient()
+    with patch(f"{AirtrainClient.__module__}.{AirtrainClient.__name__}", new=mock):
+        yield mock.return_value
+
+
+@dataclass
+class FakeDataset:
+    id: str
+    name: str
+    ingestion_job_id: Optional[str] = None
+    source_data: List[io.BufferedIOBase] = field(default_factory=list)
+    ingested: Optional[pa.Table] = None
+
+
+class MockAirtrainClient(AirtrainClient):
+    def __init__(self) -> None:
+        super().__init__(api_key="53c237", base_url="https://fake.local")
+        self._fake_datasets: Dict[str, FakeDataset] = {}
+        self.dataset_row_limit = 100
+
+    def get_fake_dataset(self, dataset_id: str) -> FakeDataset:
+        return self._fake_datasets[dataset_id]
+
+    def trigger_dataset_ingest(self, dataset_id: str) -> TriggerIngestResponse:
+        job_id = uuid.uuid4().hex
+        if dataset_id not in self._fake_datasets:
+            raise NotFoundError("Dataset not uploaded first")
+
+        table = None
+        for source in self._fake_datasets[dataset_id].source_data:
+            table_part = pq.read_table(source)
+            if table is None:
+                table = table_part
+            else:
+                table = pa.concat_tables([table, table_part])
+
+        self._fake_datasets[dataset_id].ingested = table
+        return TriggerIngestResponse(ingest_job_id=job_id)
+
+    def create_dataset(
+        self, name: str, embedding_column_name: Optional[str]
+    ) -> CreateDatasetResponse:
+        dataset_id = uuid.uuid4().hex
+        self._fake_datasets[dataset_id] = FakeDataset(id=dataset_id, name=name)
+        return CreateDatasetResponse(
+            dataset_id=dataset_id, row_limit=self.dataset_row_limit
+        )
+
+    def upload_dataset_data(self, dataset_id: str, data: io.BufferedIOBase) -> None:
+        if dataset_id not in self._fake_datasets:
+            raise NotFoundError("Dataset not uploaded first")
+        self._fake_datasets[dataset_id].source_data.append(data)

--- a/src/tests/test_core.py
+++ b/src/tests/test_core.py
@@ -1,6 +1,161 @@
-from airtrain.core import DatasetMetadata, upload_from_dicts
+from itertools import count
+
+import pyarrow as pa
+import pytest
+
+from airtrain.core import DatasetMetadata, upload_from_arrow_tables, upload_from_dicts
+from tests.fixtures import MockAirtrainClient, mock_client  # noqa: F401
 
 
-def test_upload_from_dicts():
-    result = upload_from_dicts([{"foo": 42}, {"foo": 43}], name="Foo dataset")
+def test_upload_from_dicts(mock_client: MockAirtrainClient):  # noqa: F811
+    data = [{"foo": 42}, {"foo": 43}, {"foo": 44}, {"foo": 45, "bar": "hi"}]
+    name = "Foo dataset"
+    result = upload_from_dicts(data, name=name)
     assert isinstance(result, DatasetMetadata)
+    assert result.size == len(data)
+    assert result.name == name
+    fake_dataset = mock_client.get_fake_dataset(result.id)
+    assert fake_dataset.name == name
+    table = fake_dataset.ingested
+    assert table is not None
+    assert table.shape[0] == len(data)
+    assert table["foo"].to_pylist() == [42, 43, 44, 45]
+    assert table["bar"].to_pylist() == [None, None, None, "hi"]
+
+    result = upload_from_dicts(
+        data,
+        name=name,
+        schema=pa.schema(
+            [
+                ("foo", pa.float32()),
+                ("bar", pa.string()),
+            ]
+        ),
+    )
+    fake_dataset = mock_client.get_fake_dataset(result.id)
+    table = fake_dataset.ingested
+
+    # make sure the schema was respected
+    assert all(isinstance(v, float) for v in table["foo"].to_pylist())
+
+
+def test_upload_from_dicts_limits(mock_client: MockAirtrainClient):  # noqa: F811
+    # This would go forever if the code didn't stop early.
+    data = ({"foo": i} for i in count())
+
+    row_limit = mock_client.dataset_row_limit
+    result = upload_from_dicts(data)
+    assert isinstance(result, DatasetMetadata)
+    assert result.size == row_limit
+
+
+def test_upload_from_dicts_invalid(mock_client: MockAirtrainClient):  # noqa: F811
+    data = [{"foo": 42}, {"foo": 43}, {"foo": 44}, {"foo": 45, "bar": "hi"}]
+    with pytest.raises(pa.lib.ArrowInvalid):
+        upload_from_dicts(
+            data,
+            schema=pa.schema(
+                [
+                    ("foo", pa.float32()),
+                    ("bar", pa.float32()),
+                ]
+            ),
+        )
+
+    with pytest.raises(ValueError):
+        upload_from_dicts([])
+
+    with pytest.raises(ValueError):
+        upload_from_dicts(["foo" for _ in range(0, 10)])
+
+
+def test_upload_from_dicts_embedded(mock_client: MockAirtrainClient):  # noqa: F811
+    data = [
+        {"foo": 42, "bar": [1.0, 2.0]},
+        {"foo": 43, "bar": [1.1, 2.1]},
+        {"foo": 44, "bar": [1.2, 2.2]},
+        {"foo": 45, "bar": [1.3, 2.3]},
+    ]
+
+    result = upload_from_dicts(data, embedding_column="bar")
+    assert isinstance(result, DatasetMetadata)
+
+    schema = pa.schema(
+        [
+            ("foo", pa.float32()),
+            ("bar", pa.list_(pa.float32())),
+        ]
+    )
+    result = upload_from_dicts(data, embedding_column="bar", schema=schema)
+    assert isinstance(result, DatasetMetadata)
+
+    schema = pa.schema(
+        [
+            ("foo", pa.float32()),
+            ("bar", pa.list_(pa.float32(), 2)),
+        ]
+    )
+    result = upload_from_dicts(data, embedding_column="bar", schema=schema)
+    assert isinstance(result, DatasetMetadata)
+
+    # integers should work too
+    data = [
+        {"foo": 42, "bar": [1, 2]},
+        {"foo": 43, "bar": [3, 4]},
+    ]
+    result = upload_from_dicts(data, embedding_column="bar", schema=schema)
+    assert isinstance(result, DatasetMetadata)
+
+
+def test_bad_embeds(mock_client: MockAirtrainClient):  # noqa: F811
+    data = [
+        {"foo": 42, "bar": [1.0, 2.0]},
+        {"foo": 43, "bar": [1.1, 2.1]},
+    ]
+
+    with pytest.raises(TypeError):
+        upload_from_dicts(data, embedding_column="foo")
+
+    with pytest.raises(ValueError):
+        upload_from_dicts(data, embedding_column="baz")
+
+    data = [
+        {"foo": 42, "bar": ["hi", "hi"]},
+        {"foo": 43, "bar": ["there", "there"]},
+    ]
+    with pytest.raises(TypeError):
+        upload_from_dicts(data, embedding_column="bar")
+
+    data = [
+        {"foo": 42, "bar": [1.0, 2.0]},
+        {"foo": 43, "bar": None},
+    ]
+    with pytest.raises(ValueError):
+        upload_from_dicts(data, embedding_column="bar")
+
+    data = [
+        {"foo": 42, "bar": [1.0, 2.0]},
+        {"foo": 43, "bar": [1.1, 2.1, 3.1]},
+    ]
+    with pytest.raises(ValueError):
+        upload_from_dicts(data, embedding_column="bar")
+
+
+def test_upload_from_arrow_tables(mock_client: MockAirtrainClient):  # noqa: F811
+    table_1 = pa.table({"foo": [1, 2, 3], "bar": ["a", "b", "c"]})
+    table_2 = pa.table({"foo": [4, 5, 6], "bar": ["d", "e", "f"]})
+    uploaded = upload_from_arrow_tables([table_1, table_2], name="My Arrow")
+    fake_dataset = mock_client.get_fake_dataset(uploaded.id)
+    table = fake_dataset.ingested
+    assert table is not None
+    assert table.shape[0] == table_1.shape[0] + table_2.shape[0]
+    assert table["foo"].to_pylist() == [1, 2, 3, 4, 5, 6]
+    assert table["bar"].to_pylist() == ["a", "b", "c", "d", "e", "f"]
+
+
+def test_upload_from_mismatched_tables(mock_client: MockAirtrainClient):  # noqa: F811
+    table_1 = pa.table({"foo": [1, 2, 3], "bar": ["a", "b", "c"]})
+    table_2 = pa.table({"foo": ["d", "e", "f"], "bar": [4, 5, 6]})
+
+    with pytest.raises(ValueError):
+        upload_from_arrow_tables([table_1, table_2], name="My Arrow")


### PR DESCRIPTION
Add implementation of the core dataset upload APIs. The "super simple" api is `upload_from_dicts`. It relies on
`upload_from_arrow_tables` for its implementation. Together these two are likely to be common connection points
for other integrations as `upload_from_dicts` uses a very common general python interface (iterable of dicts) for
the data, which can be produced by many other libraries (ex: ORMs), while Apache Arrow is a super-efficient
lingua-franca for many data science libraries that work with tabular data (ex: pandas, polars).

Testing
--------

Tested with driver script against dev deployment:

```python
from airtrain import upload_from_dicts


def main() -> None:
    result = upload_from_dicts(
        [{"text": "hello"}, {"text": "arrow"}, {"text": "world"}]
    )
    print(f"Uploaded {result.size} rows to {result.name}. View at: {result.url}")

if __name__ == "__main__":
    main()

```